### PR TITLE
Add HEIC support for iPhones

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ sudo apt upgrade
 Next, a few core packages need to be installed, these are mostly various helpers for installing PhotoPrism:
 
 ```shell
-$ sudo apt install -y gcc g++ git gnupg make zip unzip ffmpeg
+$ sudo apt install -y gcc g++ git gnupg make zip unzip ffmpeg libheif-examples
 ```
 
 > **Note:** If running in an environment where you're root by default, like in an LXC container, make sure sudo is installed, it'll be needed in a later step.


### PR DESCRIPTION
I added this package to core packages as I believe that without it, significant functionality is lost (no photos taken on an iPhone using the default HEIC format can be uploaded). The package is also < 30Mb so it's pretty light weight.