### PR TITLE
Re-write guide now that PhotoPrism provides Linux packages

### DIFF
--- a/MANUAL_BUILD.md
+++ b/MANUAL_BUILD.md
@@ -129,3 +129,17 @@ $ NODE_OPTIONS=--max_old_space_size=1024 make all
 ```
 
 If you're still having problems, consult [the PhotoPrism makefile](https://github.com/photoprism/photoprism/blob/release/Makefile#L34) for the steps that `make all` executes, and try running them individually to isolate the problem.
+
+## Troubleshooting
+
+If building PhotoPrism fails, you can try deleting `~/photoprism` (where you cloned the source code) and `/opt/photoprism` (where the built files were copied) and re-running the build steps PhotoPrism.
+
+In some cases you might run into a bug in PhotoPrism that has been fixed but the fix is not yet released. In that case, you can try switching to the "preview" branch (or even the bleeding-edge "develop" branch), although note that this might introduce other issues compared to the stable "release" version.
+
+To switch branches (e.g. to "preview"), go to the directory where you downloaded the PhotoPrism source code and enter the following command:
+
+```shell
+$ git checkout preview
+```
+
+Then re-run the steps to build and install PhotoPrism.

--- a/MANUAL_BUILD.md
+++ b/MANUAL_BUILD.md
@@ -1,0 +1,131 @@
+# Manual build instructions
+
+If the pre-built binaries don't work on your system for any reason, it's possible to build PhotoPrism yourself by following the below instructions.
+
+## Prerequisites
+
+If you haven't done so already, ensure your server's packages are up-to-date:
+
+```shell
+$ sudo apt update
+$ sudo apt upgrade
+```
+
+Next, a few core packages need to be installed, these are mostly various helpers for installing PhotoPrism:
+
+```shell
+$ sudo apt install -y gcc g++ git gnupg make zip unzip ffmpeg
+```
+
+> **Note:** If running in an environment where you're root by default, like in an LXC container, make sure sudo is installed, it'll be needed in a later step.
+
+Optionally, the following packages can be installed to enable better metadata extraction (exiftool) and RAW image conversion (darktable, imagemagick):
+
+```shell
+$ sudo apt install -y exiftool darktable libpng-dev libjpeg-dev libtiff-dev imagemagick
+```
+
+### Node.js
+
+[Debian 12 ships Node.js v18](https://packages.debian.org/bookworm/nodejs), which as of the writing of this is recent enough, so it can be installed from the default repos:
+
+```shell
+$ sudo apt install -y nodejs npm
+```
+
+For distros that ship an older version, or in the case that PhotoPrism starts requiring a newer version of Node.js, it should be installed from [Nodesource](https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions) instead:
+
+```shell
+$ wget https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+$ sudo mv nodesource-repo.gpg.key /etc/apt/keyrings/nodesource.asc
+$ echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+$ sudo apt update
+$ sudo apt install -y nodejs
+```
+
+### Golang
+
+While [Golang](https://go.dev/) is available in Debian (and Ubuntu) repos, the version is usually outdated (even in Debian backports). For the most up-to-date version, to keep up with what PhotoPrism uses, Golang needs to be downloaded and installed manually. The latest version as of the writing of this is 1.21.1, but [check the website](https://go.dev/dl/) and change the URLs below if necessary:
+
+```shell
+$ wget https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
+$ sudo rm -rf /usr/local/go
+$ sudo tar -C /usr/local -xzf go1.21.1.linux-amd64.tar.gz
+$ sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+$ rm go1.21.1.linux-amd64.tar.gz
+```
+
+This downloads and extracts Golang to `/usr/local/go` (deleting old installation, if it exists), and creates a symlink to the `go` binary in `/usr/local/bin` (so it's in the $PATH).
+
+> **Note:** For ARM-based devices like the Raspberry Pi, download the arm64 or armv6l version instead, depending on whether you have a 64-bit or 32-bit OS.
+
+### Tensorflow
+
+[Tensorflow](https://www.tensorflow.org/) is an AI library developed by Google. PhotoPrism uses it to classify photos and detect faces. The necessary version (1.15, as of the writing of this) can be downloaded from the PhotoPrism website.
+
+Choose the appropriate Tensorflow build based on whether your CPU supports the [AVX or AVX2 instruction sets](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). You can check by running `lscpu | grep -Eo 'avx2?\W'`.
+
+If you have [a reasonably recent CPU](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX2), you'll want the "avx2" version:
+
+```shell
+$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-avx2-1.15.2.tar.gz
+$ sudo tar -C /usr/local -xzf libtensorflow-linux-avx2-1.15.2.tar.gz
+$ sudo ldconfig
+$ rm libtensorflow-linux-avx2-1.15.2.tar.gz
+```
+
+For [older CPUs](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX), use the "avx" version:
+
+```shell
+$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-avx-1.15.2.tar.gz
+$ sudo tar -C /usr/local -xzf libtensorflow-linux-avx-1.15.2.tar.gz
+$ sudo ldconfig
+$ rm libtensorflow-linux-avx-1.15.2.tar.gz
+```
+
+If your CPU supports neither instruction set, use the "cpu" version:
+
+```shell
+$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-cpu-1.15.2.tar.gz
+$ sudo tar -C /usr/local -xzf libtensorflow-linux-cpu-1.15.2.tar.gz
+$ sudo ldconfig
+$ rm libtensorflow-linux-cpu-1.15.2.tar.gz
+```
+
+If an unsupported version is chosen, the PhotoPrism service will fail to start with an "Illegal operation" error. To repair, just run the above steps again with the corrected archive path.
+
+See <https://dl.photoprism.org/tensorflow> for download URLs for other platforms (like ARM).
+
+## Download and install PhotoPrism
+
+Create a directory where the compiled PhotoPrism code will be stored:
+
+```shell
+$ sudo mkdir -p /opt/photoprism/bin
+```
+
+Now download the PhotoPrism source code:
+
+```shell
+$ git clone https://github.com/photoprism/photoprism.git
+$ cd photoprism
+$ git checkout release
+```
+
+Then run the following commands to download the various dependencies for Tensorflow, the Node.js front-end and the Golang back-end, and install PhotoPrism in `/opt/photoprism`:
+
+```shell
+$ sudo make all
+$ sudo ./scripts/build.sh prod /opt/photoprism/bin/photoprism
+$ sudo cp -a assets/ /opt/photoprism/assets/
+```
+
+The dependencies step can produce errors when running in shells like ZSH. Ensure you're using Bash if this happens.
+
+Building the front-end can take more than 1 GB of RAM, and the build might crash with Javascript running out of memory. If using a virtual machine, allocate at least 2 GB. Alternatively, you can try limiting Node's memory usage as follows (adjust the number based on available RAM on your system):
+
+```shell
+$ NODE_OPTIONS=--max_old_space_size=1024 make all
+```
+
+If you're still having problems, consult [the PhotoPrism makefile](https://github.com/photoprism/photoprism/blob/release/Makefile#L34) for the steps that `make all` executes, and try running them individually to isolate the problem.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ This guide is provided in good faith and for informational purposes only. No cla
 
 ## Installing PhotoPrism
 
+### Prerequisites
+
+If you haven't done so already, ensure your server's packages are up-to-date:
+
+```shell
+$ sudo apt update
+$ sudo apt dist-upgrade
+```
+
+Next, a few optional packages can be installed to enable extra features like better metadata extraction and RAW image conversion:
+
+```shell
+$ sudo apt install -y ffmpeg exiftool darktable libpng-dev libjpeg-dev libtiff-dev imagemagick
+```
+
 ### Download PhotoPrism
 
 PhotoPrism provides [pre-built Linux packages](https://dl.photoprism.app/pkg/linux/) on their website. Download the latest build and extract it to `/opt/photoprism`:
@@ -234,7 +249,7 @@ First, update your system:
 
 ```shell
 $ sudo apt update
-$ sudo apt upgrade
+$ sudo apt dist-upgrade
 ```
 
 Then, stop the PhotoPrism service:

--- a/README.md
+++ b/README.md
@@ -228,9 +228,7 @@ $ systemctl list-timers photoprism-bg
 
 ## Updating PhotoPrism
 
-New versions of PhotoPrism are published to their Github repository: https://github.com/photoprism/photoprism/releases
-
-If a new version is published, the following steps need to be done.
+When a new version of PhotoPrism is published, the following steps need to be done.
 
 First, update your system:
 
@@ -239,31 +237,34 @@ $ sudo apt update
 $ sudo apt upgrade
 ```
 
-Also check for new Golang version and install manually using [the instructions from above](#golang).
-
 Then, stop the PhotoPrism service:
 
 ```shell
 $ sudo systemctl stop photoprism
 ```
 
-Then, navigate to the PhotoPrism source code directory and pull the latest version from Github:
+Delete the contents of the directory where you extracted the PhotoPrism build package:
 
 ```shell
-$ cd photoprism
-$ git pull --force
+$ sudo rm -rf /opt/photoprism/*
 ```
 
-Upgrade dependencies and re-run the build steps from above.
+Optionally, make a backup copy of the directory first so you can easily revert if necessary:
 
 ```shell
-$ sudo make upgrade
-$ sudo make all
-$ sudo ./scripts/build.sh prod /opt/photoprism/bin/photoprism
-$ sudo rm -rf /opt/photoprism/assets/
-$ sudo cp -a assets/ /opt/photoprism/assets/
+$ sudo cp /opt/photoprism/ /opt/photoprism.bak/
+```
+
+Download the latest build and extract it:
+
+```shell
+$ wget https://dl.photoprism.app/pkg/linux/amd64.tar.gz
+$ sudo tar xzf amd64.tar.gz -C /opt/photoprism/
 $ sudo chown -R photoprism:photoprism /opt/photoprism
+$ rm amd64.tar.gz
 ```
+
+As before, change the URLs and filenames if you're running on an ARM-based system.
 
 Finally, restart the PhotoPrism service:
 
@@ -279,16 +280,10 @@ Run the following command to check the service status:
 $ systemctl status photoprism
 ```
 
-Also check the [PhotoPrism troubleshooting checklists](https://docs.photoprism.app/getting-started/troubleshooting/). Some of the information there is Docker-specific, but a lot is useful even with non-Docker setups.
-
-If all else fails, you can try deleting `~/photoprism` (where you cloned the source code) and `/opt/photoprism` (where the built files were copied) and re-installing PhotoPrism. As long as you don't delete `/var/lib/photoprism`, your data and settings won't be lost.
-
-In some cases you might run into a bug in PhotoPrism that has been fixed but the fix is not yet released. In that case, you can try switching to the "preview" branch (or even the bleeding-edge "develop" branch), although note that this might introduce other issues compared to the stable "release" version.
-
-To switch branches (e.g. to "preview"), go to the directory where you downloaded the PhotoPrism source code and enter the following command:
+The following command can provide more information:
 
 ```shell
-$ git checkout preview
+$ sudo journalctl -u photoprism.service
 ```
 
-Then re-run the steps to build and install PhotoPrism.
+Also check the [PhotoPrism troubleshooting checklists](https://docs.photoprism.app/getting-started/troubleshooting/). Some of the information there is Docker-specific, but a lot is useful even with non-Docker setups.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 
 ### Why this guide?
 
-The [PhotoPrism documentation](https://docs.photoprism.org/getting-started/) only covers Docker as an officially supported installation method. However, not everyone can, or wants to, use Docker. The only [guide that covers installation without Docker](https://web.archive.org/web/20200812001802/https://docs.photoprism.org/developer-guide/setup-fedora/#development-environment-fedora-32) is focused on development, and includes steps that are not necessary when one simply wants to run PhotoPrism.
-
-The purpose of this guide, therefore, is to provide instructions for setting up a usable PhotoPrism installation on [Debian](https://www.debian.org/). The guide has been written for, and tested on, Debian 12 "Bookworm", but should also work on older versions like Debian 11 "Bullseye", as well as derivatives like Ubuntu and Raspbian.
+The [PhotoPrism documentation](https://docs.photoprism.app/getting-started/) recommends Docker as the installation method. However, not everyone can, or wants to, use Docker. The purpose of this guide, therefore, is to provide instructions for setting up a usable PhotoPrism installation on [Debian](https://www.debian.org/). The guide has been written for, and tested on, Debian 12 "Bookworm", but should also work on older versions like Debian 11 "Bullseye", as well as derivatives like Ubuntu and Raspbian.
 
 ## DISCLAIMER
 
@@ -18,133 +16,22 @@ This guide is provided in good faith and for informational purposes only. No cla
 
 ## Installing PhotoPrism
 
-### Prerequisites
+### Download PhotoPrism
 
-If you haven't done so already, ensure your server's packages are up-to-date:
-
-```shell
-$ sudo apt update
-$ sudo apt upgrade
-```
-
-Next, a few core packages need to be installed, these are mostly various helpers for installing PhotoPrism:
+PhotoPrism provides [pre-built Linux packages](https://dl.photoprism.app/pkg/linux/) on their website. Download the latest build and extract it to `/opt/photoprism`:
 
 ```shell
-$ sudo apt install -y gcc g++ git gnupg make zip unzip ffmpeg
+$ wget https://dl.photoprism.app/pkg/linux/amd64.tar.gz
+$ sudo mkdir /opt/photoprism
+$ sudo tar xzf amd64.tar.gz -C /opt/photoprism/
+$ rm amd64.tar.gz
 ```
 
-> **Note:** If running in an environment where you're root by default, like in an LXC container, make sure sudo is installed, it'll be needed in a later step.
+If you're using an ARM-based system like a Raspberry Pi, you'll need to download the ARM64 build instead, so change the URLs and filenames accordingly.
 
-Optionally, the following packages can be installed to enable better metadata extraction (exiftool) and RAW image conversion (darktable, imagemagick):
+You can run `/opt/photoprism/bin/photoprism -v` to verify the version.
 
-```shell
-$ sudo apt install -y exiftool darktable libpng-dev libjpeg-dev libtiff-dev imagemagick
-```
-
-#### Node.js
-
-[Debian 12 ships Node.js v18](https://packages.debian.org/bookworm/nodejs), which as of the writing of this is recent enough, so it can be installed from the default repos:
-
-```shell
-$ sudo apt install -y nodejs npm
-```
-
-For distros that ship an older version, or in the case that PhotoPrism starts requiring a newer version of Node.js, it should be installed from [Nodesource](https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions) instead:
-
-```shell
-$ wget https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
-$ sudo mv nodesource-repo.gpg.key /etc/apt/keyrings/nodesource.asc
-$ echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-$ sudo apt update
-$ sudo apt install -y nodejs
-```
-
-#### Golang
-
-While [Golang](https://go.dev/) is available in Debian (and Ubuntu) repos, the version is usually outdated (even in Debian backports). For the most up-to-date version, to keep up with what PhotoPrism uses, Golang needs to be downloaded and installed manually. The latest version as of the writing of this is 1.21.1, but [check the website](https://go.dev/dl/) and change the URLs below if necessary:
-
-```shell
-$ wget https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
-$ sudo rm -rf /usr/local/go
-$ sudo tar -C /usr/local -xzf go1.21.1.linux-amd64.tar.gz
-$ sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-$ rm go1.21.1.linux-amd64.tar.gz
-```
-
-This downloads and extracts Golang to `/usr/local/go` (deleting old installation, if it exists), and creates a symlink to the `go` binary in `/usr/local/bin` (so it's in the $PATH).
-
-> **Note:** For ARM-based devices like the Raspberry Pi, download the arm64 or armv6l version instead, depending on whether you have a 64-bit or 32-bit OS.
-
-#### Tensorflow
-
-[Tensorflow](https://www.tensorflow.org/) is an AI library developed by Google. PhotoPrism uses it to classify photos and detect faces. The necessary version (1.15, as of the writing of this) can be downloaded from the PhotoPrism website. 
-
-Choose the appropriate Tensorflow build based on whether your CPU supports the [AVX or AVX2 instruction sets](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). You can check by running `lscpu | grep -Eo 'avx2?\W'`.
-
-If you have [a reasonably recent CPU](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX2), you'll want the "avx2" version:
-
-```shell
-$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-avx2-1.15.2.tar.gz
-$ sudo tar -C /usr/local -xzf libtensorflow-linux-avx2-1.15.2.tar.gz
-$ sudo ldconfig
-$ rm libtensorflow-linux-avx2-1.15.2.tar.gz
-```
-
-For [older CPUs](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX), use the "avx" version:
-
-```shell
-$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-avx-1.15.2.tar.gz
-$ sudo tar -C /usr/local -xzf libtensorflow-linux-avx-1.15.2.tar.gz
-$ sudo ldconfig
-$ rm libtensorflow-linux-avx-1.15.2.tar.gz
-```
-
-If your CPU supports neither instruction set, use the "cpu" version:
-
-```shell
-$ wget https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-cpu-1.15.2.tar.gz
-$ sudo tar -C /usr/local -xzf libtensorflow-linux-cpu-1.15.2.tar.gz
-$ sudo ldconfig
-$ rm libtensorflow-linux-cpu-1.15.2.tar.gz
-```
-
-If an unsupported version is chosen, the PhotoPrism service will fail to start with an "Illegal operation" error. To repair, just run the above steps again with the corrected archive path.
-
-See <https://dl.photoprism.org/tensorflow> for download URLs for other platforms (like ARM).
-
-### Download and install PhotoPrism
-
-Create a directory where the compiled PhotoPrism code will be stored:
-
-```shell
-$ sudo mkdir -p /opt/photoprism/bin
-```
-
-Now download the PhotoPrism source code:
-
-```shell
-$ git clone https://github.com/photoprism/photoprism.git
-$ cd photoprism
-$ git checkout release
-```
-
-Then run the following commands to download the various dependencies for Tensorflow, the Node.js front-end and the Golang back-end, and install PhotoPrism in `/opt/photoprism`:
-
-```shell
-$ sudo make all
-$ sudo ./scripts/build.sh prod /opt/photoprism/bin/photoprism
-$ sudo cp -a assets/ /opt/photoprism/assets/
-```
-
-The dependencies step can produce errors when running in shells like ZSH. Ensure you're using Bash if this happens.
-
-Building the front-end can take more than 1 GB of RAM, and the build might crash with Javascript running out of memory. If using a virtual machine, allocate at least 2 GB. Alternatively, you can try limiting Node's memory usage as follows (adjust the number based on available RAM on your system):
-
-```shell
-$ NODE_OPTIONS=--max_old_space_size=1024 make all
-```
-
-If you're still having problems, consult [the PhotoPrism makefile](https://github.com/photoprism/photoprism/blob/release/Makefile#L34) for the steps that `make all` executes, and try running them individually to isolate the problem.
+If the pre-built package does not work on your system for some reason, it's possible to [build PhotoPrism manually](MANUAL_BUILD.md).
 
 ### Configure PhotoPrism
 
@@ -175,7 +62,7 @@ $ sudo nano .env
 
 This opens the file in the [Nano](https://www.nano-editor.org/) text editor. Feel free to use another editor if you have a preference, but this guide will assume Nano.
 
-The full list of configuration options is available [here](https://docs.photoprism.org/getting-started/config-options/), but you can use the following as a starting point:
+The full list of configuration options is available [here](https://docs.photoprism.app/getting-started/config-options/), but you can use the following as a starting point:
 
 ```
 # Initial password for the admin user


### PR DESCRIPTION
The manual build process is now unnecessary, but the instructions are preserved in a separate document, in case the pre-built packages don't work for some reason (e.g. running on an older Debian/Ubuntu release).

resolves #22 